### PR TITLE
アルファベット1文字での検索に対応

### DIFF
--- a/lib/fulltext_searchable/mysql2_adapter.rb
+++ b/lib/fulltext_searchable/mysql2_adapter.rb
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS `#{::FulltextSearchable::TABLE_NAME}` (
   #{"`_score` FLOAT," unless mroonga_match_against?}
   PRIMARY KEY(`key`),
   #{"UNIQUE " if mroonga_unique_hash_index_safe?}INDEX(`_id`) USING HASH,
-  FULLTEXT INDEX (`text`)
+  FULLTEXT INDEX (`text`) COMMENT 'parser "TokenBigramSplitSymbolAlpha"'
 ) ENGINE = #{mroonga_storage_engine_name} COLLATE utf8_unicode_ci;
 SQL
       )
@@ -53,7 +53,7 @@ SQL
       safe = true
       begin
         execute("TRUNCATE TABLE `#{temporary_table_name}`;")
-      rescue 
+      rescue
         safe = false
       end
       drop_table temporary_table_name

--- a/spec/models/fulltext_index_spec.rb
+++ b/spec/models/fulltext_index_spec.rb
@@ -31,8 +31,9 @@ describe FulltextIndex do
       FactoryGirl.create(:soneki)
       FactoryGirl.create(:eigyo)
       FactoryGirl.create(:rieki)
-      @taro = FactoryGirl.create(:taro)
-      @jiro = FactoryGirl.create(:jiro)
+      @taro   = FactoryGirl.create(:taro)
+      @jiro   = FactoryGirl.create(:jiro)
+      @hanako = FactoryGirl.create(:hanako, :name => 'hanako')
     end
     it "should fulltext searchable with '営業'" do
       FulltextIndex.match('営業').items.count.should == 4
@@ -74,7 +75,7 @@ describe FulltextIndex do
       FulltextIndex.match('天気', :with => [@taro, @jiro], :model => Blog).items.count.should == 3
       FulltextIndex.match('天気', :with => [@taro, @jiro], :model => [Blog, User]).items.count.should == 5
     end
-    
+
     it "should not break with ActiveRecord's eager loading behavior" do
       expect{ FulltextIndex.match('ab.').items }.not_to raise_error
     end
@@ -96,6 +97,12 @@ describe FulltextIndex do
       end
       FulltextIndex.match('++太郎', :model => User).items.count.should == 1
       FulltextIndex.match(['+太郎'], :model => User).items.count.should == 1
+    end
+
+    it "should fulltext searchable with one character of alphabet" do
+      FulltextIndex.match('h').items.count.should == 1
+      FulltextIndex.match('h', :model => User).items.count.should == 1
+      FulltextIndex.match('h', :model => User, :with => @hanako).items.count.should == 1
     end
   end
 


### PR DESCRIPTION
掲題の通りです。

【修正内容】
トークナイザーを(デフォルトTokenBigramから)TokenBigramSplitSymbolAlphaへ変更。
