### PR TITLE
検索文字列のエスケープを追加

### DIFF
--- a/app/models/fulltext_index.rb
+++ b/app/models/fulltext_index.rb
@@ -38,6 +38,10 @@ class FulltextIndex < ActiveRecord::Base
       phrase = phrase.split(/[\s　]/) if phrase.is_a? String
       phrase.map!{|word| word.gsub(BOOLEAN_META_CHARACTER_REGEXP, '')}
       phrase.reject!(&:blank?)
+      # escape special character
+      phrase.map! do |word|
+        '"' + word.gsub(/[\\"]/) { |c| "\\#{c}" } + '"'
+      end
 
       # モデルで絞り込む
       model_keywords = []

--- a/app/models/fulltext_index.rb
+++ b/app/models/fulltext_index.rb
@@ -35,10 +35,9 @@ class FulltextIndex < ActiveRecord::Base
     #
     def match(phrase, options={})
       options = options.symbolize_keys
-      if phrase.is_a? String
-        phrase = phrase.split(/[\s　]/).reject{|word| word.blank? }
-      end
+      phrase = phrase.split(/[\s　]/) if phrase.is_a? String
       phrase.map!{|word| word.gsub(BOOLEAN_META_CHARACTER_REGEXP, '')}
+      phrase.reject!(&:blank?)
 
       # モデルで絞り込む
       model_keywords = []

--- a/spec/models/fulltext_index_spec.rb
+++ b/spec/models/fulltext_index_spec.rb
@@ -115,6 +115,37 @@ describe FulltextIndex do
     end
   end
 
+  describe 'special chars matchings' do
+    before do
+      names = %w(
+        Asterisk
+        Asterisk*
+        テスト
+        テスト++
+        タマ
+        タマ(猫)
+        HELLO!!
+        "HELLO!!"
+        STRING
+        STRING\"\"
+        OR
+      )
+      names.each do |name|
+        FactoryGirl.create(:user, name: name, blogs: [])
+      end
+    end
+
+    it 'should work with special chars' do
+      expect(FulltextIndex.match('Asterisk*').size).to eq 1
+      expect(FulltextIndex.match('ト++').size).to eq 1
+      expect(FulltextIndex.match('タマ(猫)').size).to eq 1
+      expect(FulltextIndex.match('タマ(').size).to eq 1
+      expect(FulltextIndex.match('"HELLO!!"').size).to eq 1
+      expect(FulltextIndex.match('STRING\\"\\"').size).to eq 1
+      expect(FulltextIndex.match('OR').size).to eq 1
+    end
+  end
+
   context "optimization" do
     before do
       @taro = FactoryGirl.create(:taro)

--- a/spec/models/fulltext_index_spec.rb
+++ b/spec/models/fulltext_index_spec.rb
@@ -35,6 +35,7 @@ describe FulltextIndex do
       @jiro   = FactoryGirl.create(:jiro)
       @hanako = FactoryGirl.create(:hanako, :name => 'hanako')
     end
+
     it "should fulltext searchable with '営業'" do
       FulltextIndex.match('営業').items.count.should == 4
     end
@@ -103,6 +104,14 @@ describe FulltextIndex do
       FulltextIndex.match('h').items.count.should == 1
       FulltextIndex.match('h', :model => User).items.count.should == 1
       FulltextIndex.match('h', :model => User, :with => @hanako).items.count.should == 1
+    end
+
+    it 'should not raise error searchable with only meta character string' do
+      expect {
+        expect(FulltextIndex.match('(').size).to eq 0
+        expect(FulltextIndex.match('++++++').size).to eq 0
+        expect(FulltextIndex.match(')+()()())---->*<').size).to eq 0
+      }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
文字列中にある特殊文字によりエラーにならないよう、検索クエリーの文字列に対してエスケープを適用するように変更。
